### PR TITLE
Check for redirecting pages if links.redirects is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ exclude:
   # - img.domain.com/*
 
 links:
-  www: true                   # Autom. link any hostname that starts with "www."
+  www: false                  # Autom. link any hostname that starts with "www."
+
+  redirects: false            # Also mark links as external, that link to pages 
+                              # that redirect to an external URL
 
   schemes:                    # Allowed schemes
     - 'http'

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -81,6 +81,17 @@ form:
                   validate:
                     type: bool
 
+                links.redirects:
+                  type: toggle
+                  label: PLUGINS.EXTERNAL_LINKS.LINKS.REDIRECTS
+                  help: PLUGINS.EXTERNAL_LINKS.LINKS.REDIRECTS_HELP
+                  default: 0
+                  options:
+                    1: PLUGIN_ADMIN.YES
+                    0: PLUGIN_ADMIN.NO
+                  validate:
+                    type: bool
+
                 links.schemes:
                   type: selectize
                   size: large

--- a/classes/ExternalLinks.php
+++ b/classes/ExternalLinks.php
@@ -209,18 +209,26 @@ class ExternalLinks
                     // The protocol turns out be an allowed protocol
                     $external = $url;
                 }
-            } elseif ($config->get('plugins.external_links.links.www')) {
-                // Remove possible path duplicate
-                $route = Grav::instance()['base_url'] . $page->route();
-                $href = Utils::startsWith($url, $route)
-                  ? ltrim(mb_substr($url, mb_strlen($route)), '/')
-                  : $url;
+            }  else {
+                if ($config->get('plugins.external_links.links.www')) {
+                    // Remove possible path duplicate
+                    $route = Grav::instance()['base_url'] . $page->route();
+                    $href = Utils::startsWith($url, $route)
+                        ? ltrim(mb_substr($url, mb_strlen($route)), '/')
+                        : $url;
 
-                // We found an url without protocol, but with starting 'www' (sub-)domain
-                if (Utils::startsWith($url, 'www.')) {
-                    $external = 'http://' . $url;
-                } elseif (Utils::startsWith($href, 'www.')) {
-                    $external = 'http://' . $href;
+                    // We found an url without protocol, but with starting 'www' (sub-)domain
+                    if (Utils::startsWith($url, 'www.')) {
+                        $external = 'http://' . $url;
+                    } elseif (Utils::startsWith($href, 'www.')) {
+                        $external = 'http://' . $href;
+                    }
+                }
+                if ($config->get('plugins.external_links.links.redirects')) {
+                    $targetPage = Grav::instance()['pages']->find($url);
+                    if ($targetPage && $targetPage->redirect()) {
+                        $external = $this->isExternalUrl($targetPage->redirect(), $domains, $page);
+                    }
                 }
             }
         }

--- a/external_links.yaml
+++ b/external_links.yaml
@@ -15,6 +15,8 @@ exclude:
 links:
   www: false                  # Autom. link any hostname that starts with "www."
 
+  redirects: false            # Also mark links as external, that link to pages that redirect to an external URL
+
   schemes:                    # Allowed schemes
     - 'http'
     - 'https'

--- a/languages.yaml
+++ b/languages.yaml
@@ -29,6 +29,9 @@ de:
         WWW: "Verlinkung (WWW)"
         WWW_HELP: "Verlinke auch Links, die mit 'www.' beginnen als extern"
 
+        REDIRECTS: "Folge Seiten-Weiterleitungen"
+        REDIRECTS_HELP: "Links zu Seiten, die zu einer externen URL weiterleiten werden auch als extern markiert"
+
         SCHEMES: "Erlaubte Protokolle"
         SCHEMES_HELP: "Liste von erlaubten Protokollen"
 
@@ -79,6 +82,9 @@ en:
 
         WWW: "Link WWW"
         WWW_HELP: "Automatically link any hostname that starts with 'www.' as external"
+
+        REDIRECTS: "Follow Page redirects"
+        REDIRECTS_HELP: "Also mark links as external, that link to pages that redirect to an external URL"
 
         SCHEMES: "Allowed schemes"
         SCHEMES_HELP: "List of allowed schemes"
@@ -131,6 +137,9 @@ fr:
         WWW: "Liens WWW"
         WWW_HELP: "Reconnaître automatiquement tout lien commencant par 'www.' comme étant un lien externe."
 
+        REDIRECTS: "Follow Page redirects"
+        REDIRECTS_HELP: "Also mark links as external, that link to pages that redirect to an external URL"
+
         SCHEMES: "Schémas autorisés"
         SCHEMES_HELP: "Liste des schémas autorisés"
 
@@ -181,6 +190,9 @@ ru:
 
         WWW: "Ссылка WWW"
         WWW_HELP: "Автоматически связывать любое имя хоста, которое начинается с 'www'. как внешние"
+
+        REDIRECTS: "Follow Page redirects"
+        REDIRECTS_HELP: "Also mark links as external, that link to pages that redirect to an external URL"
 
         SCHEMES: "Допустимые схемы"
         SCHEMES_HELP: "Список допустимых схем"


### PR DESCRIPTION
This is related to the feature request #20 I did some time ago.

- I was not sure about the `languages.yaml` so I did put the english translation for the languages I didn't know.
- The contribution docs tell me to write tests for any added functionality, but I didn't see any test infrastructure I could add something to.
- Personally I would prefer to enable the redirects option by default, but since I was not sure I choose the option with the fewest possible impact.

### Implementation details:
- to allow for the same code to enhance the links class and attribute I actually modified the method `isExternalLink`.
- Since pages can redirect to other pages, I added a recursive call (circular redirects might cause the page containing a link to that "circular page" to crash with something like stackoverflow. But I think this is an edge case.
- The change in the `README.md` regarding `links.www` to `false` is just reflecting the value in `external_links.yaml`. If you think this doesn't belong into this PR I cant change it back.

