### PR TITLE
fix loading of a href element

### DIFF
--- a/classes/ExternalLinks.php
+++ b/classes/ExternalLinks.php
@@ -50,7 +50,10 @@ class ExternalLinks
                 }
 
                 $a = $dom->getElementsByTagName('a')->item(0);
-
+                if (is_null($a)) {
+                    return $match[0];
+                }
+                    
                 // Process links with non-empty href attribute
                 $href = $a->getAttribute('href');
                 if (strlen($href) == 0) {


### PR DESCRIPTION
it can happen, that this function will fail in case of <abrr> <a></a> etc or or other issues. i would say it is a good idea to do additional error checking so that $a->getAttribute will not throw exception when a is null.