### PR TITLE
FlexObjects compatibility: changed references to Page class to use PageInterface

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -11,6 +11,9 @@ docs: 'https://github.com/sommerregen/grav-plugin-external-links/blob/master/REA
 bugs: 'https://github.com/sommerregen/grav-plugin-external-links/issues'
 license: 'MIT/GPL'
 
+dependencies:
+    - { name: grav, version: '>=1.6.4' }
+    
 form:
   validation: strict
 

--- a/external_links.php
+++ b/external_links.php
@@ -20,7 +20,7 @@
 namespace Grav\Plugin;
 
 use Grav\Common\Plugin;
-use Grav\Common\Page\Page;
+use Grav\Common\Page\Interfaces\PageInterface;
 use Grav\Common\Data\Blueprints;
 
 use RocketTheme\Toolbox\Event\Event;
@@ -189,7 +189,7 @@ class ExternalLinksPlugin extends Plugin
      * @return boolean       Returns true if page has already been
      *                       compiled yet, false otherwise
      */
-    protected function compileOnce(Page $page)
+    protected function compileOnce(PageInterface $page)
     {
         static $processed = [];
 


### PR DESCRIPTION
This PR is to make External Links compatible with the new Flex Pages (front-end) upcoming in Grav 1.7. Related issue (with comment from Matias from Grav Core Team): https://github.com/Sommerregen/grav-plugin-external-links/issues/30

Please let me know if you need any more info or if I can help further with testing etc.

Thanks,
Paul