### PR TITLE
[fix] Avoid conflict with colored bootstrap button

### DIFF
--- a/assets/css/external_links.css
+++ b/assets/css/external_links.css
@@ -1,10 +1,14 @@
 a.external-link.icon, a.external-link.no-image, a.external, a.external {
-  background: url(../images/link.png) right center no-repeat;
+  background-image: url(../images/link.png);
+  background-position: right center;
+  background-repeat: no-repeat;
   padding-right: 12px;
   position: relative;
 }
 a.mailto {
-  background: url(../images/mail.png) right center no-repeat;
+  background-image: url(../images/mail.png);
+  background-position: right center;
+  background-repeat: no-repeat;
   padding-right: 12px;
 }
 


### PR DESCRIPTION
When we use colored bootstrap button, the background color is replace by transparent, and white text become unreadable.

![bug](https://user-images.githubusercontent.com/4080016/125166340-80156b80-e19b-11eb-9ad7-3cbe3a40fdf1.png)
